### PR TITLE
Update __init__.py

### DIFF
--- a/src/ezsheets/__init__.py
+++ b/src/ezsheets/__init__.py
@@ -152,7 +152,7 @@ def _makeRequest(requestType, **kwargs):
             return request.execute()
         except HttpError as e:
             errorContent = json.loads(str(e.content, encoding="utf-8"))
-            if errorContent["error"]["errors"][0]["reason"] != "rateLimitExceeded":
+            if errorContent['error']['status'] != 'RESOURCE_EXHAUSTED':
                 raise  # Some other, non-quota-related HttpError was raised, so we'll just re-raise it here.
             if pauseLength == 50:
                 raise  # Throttling doesn't seem to work. Give up, and re-raise the error.


### PR DESCRIPTION
To fix the issue #7. The fix is based on the following content of "errorContent" variable printed out during the debugging (with possible confidential data replaced by 'X'):
`{'error': {'code': 429, 'message': "Quota exceeded for quota group 'ReadGroup' and limit 'Read requests per user per 100 seconds' of service 'sheets.googleapis.com' for consumer 'project_number:XXXXXXXXXXXX'.", 'status': 'RESOURCE_EXHAUSTED', 'details': [{'@type': 'type.googleapis.com/google.rpc.Help', 'links': [{'description': 'Google developer console API key', 'url': 'https://console.developers.google.com/project/XXXXXXXXXXXX/apiui/credential'}]}]}}`