### PR TITLE
Fix README - getAll() is not a thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also get or update data in a specific cell, row, or column:
     >>> sh.getColumn(1)
     ['cell A', 'another value']
     >>> sh.updateAll([['CELL A', 'ANOTHER VALUE', 'CELL C'], ['ANOTHER VALUE']])
-    >>> sh.getAll()
+    >>> sh.getRows()
     [['CELL A', 'ANOTHER VALUE', 'CELL C'], ['ANOTHER VALUE']]
 
 If the data on the Google Sheet changes, you can refresh your local copy of the data:


### PR DESCRIPTION
Hey Al,
This little guy had me searching through the source to figure out why my thing wasn't working :)
`sh.getAll()` doesn't exist, but `sh.getRows()` (with no arguments) does what would be expected from `getAll()`
Thanks for all you do for the community!
Ryan