### PR TITLE
Ignore Sheets with SheetTypes other than GRID

### DIFF
--- a/src/ezsheets/__init__.py
+++ b/src/ezsheets/__init__.py
@@ -249,9 +249,10 @@ class Spreadsheet:
                 self.sheets[existingSheetIndex]._refreshData()
             else:
                 # If the sheet hasn't been seen before, create a new Sheet object:
-                replacementSheetsAttr.append(
-                    Sheet(self, sheetId)
-                )  # TODO - would be nice to reuse the info in `response` for this instead of letting the ctor make another request, but this isn't that important.
+                if (sheetInfo["properties"]["sheetType"] == "GRID"):
+                    replacementSheetsAttr.append(
+                        Sheet(self, sheetId)
+                    )  # TODO - would be nice to reuse the info in `response` for this instead of letting the ctor make another request, but this isn't that important.
 
         self.sheets = tuple(replacementSheetsAttr)  # Make sheets attribute an immutable tuple.
 


### PR DESCRIPTION
Hi... first time ever forking/pull requesting/contributing/etc.
Feel free to ignore or make this fix elsewhere...

I ran into errors when trying to work on Spreadsheets containing sheets other than Grids. (In my case, I was trying to work on Spreadsheets that has charts as their own sheets -- an OBJECT type from checking the Sheets API doc.)
I've added a line that ensures new Sheet objects (upon first setting up the Sheets inside Spreadsheet, i think) are only created from GRID SheetTypes, as the other refresh functions that run anyway work on attributes not found in other types, ergo the errors (based on my understanding of the program).
Adding this check cleared everything up for me. Hopefully it's a solid fix (for now, so long as we're holding off support for other sheetTypes) and doesn't cause issues elsewhere. Thanks, –J