### PR TITLE
Add licence file into sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='GPLv3+',
+    license_files=["LICENSE.txt"],
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     test_suite='tests',


### PR DESCRIPTION
I'm in the process of adding this package to Conda Forge, and they recommend the license file to be bundled in with the sdist.